### PR TITLE
Made tabs within Internal Tools responsive for mobile and desktop

### DIFF
--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -14,7 +14,8 @@ const TabsList = React.forwardRef<
 	<TabsPrimitive.List
 		ref={ref}
 		className={cn(
-			"inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+			"flex flex-col w-full gap-2 bg-transparent border-none p-0",
+			"sm:grid sm:grid-cols-4 sm:rounded-md sm:bg-muted sm:p-1 sm:text-muted-foreground",
 			className
 		)}
 		{...props}
@@ -29,7 +30,10 @@ const TabsTrigger = React.forwardRef<
 	<TabsPrimitive.Trigger
 		ref={ref}
 		className={cn(
-			"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+			"flex-1 w-full flex items-center justify-start gap-2 rounded-none px-3 py-2 text-sm font-medium",
+			"data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none",
+			"sm:justify-center sm:rounded-sm sm:px-3 sm:py-1.5",
+			"sm:data-[state=active]:bg-background sm:data-[state=active]:shadow-sm",
 			className
 		)}
 		{...props}


### PR DESCRIPTION
Improvements:
- Mobile: Tabs now span horizontally evenly, without jumping together
- Desktop: Remains the same. Tabs are in a 4-column grid with the initial grey background, evenly spaced out.